### PR TITLE
Add tests for derived tables from fbtest.

### DIFF
--- a/tests/functional/arno/derived_tables/test_23.py
+++ b/tests/functional/arno/derived_tables/test_23.py
@@ -1,0 +1,56 @@
+#coding:utf-8
+
+"""
+ID:          derived-table-23
+TITLE:       Derived table with outer reference from JOIN.
+DESCRIPTION: Outer reference inside derived table to other relations in from clause is not allowed.
+FBTEST:      functional.arno.derived_tables.25
+"""
+
+import pytest
+from firebird.qa import *
+
+init_script = """CREATE TABLE Table_10 (
+  ID INTEGER NOT NULL,
+  DESCRIPTION VARCHAR(10)
+);
+
+COMMIT;
+
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (0, NULL);
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (1, 'one');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (2, 'two');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (3, 'three');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (4, 'four');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (5, 'five');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (6, 'six');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (7, 'seven');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (8, 'eight');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (9, 'nine');
+
+COMMIT;"""
+
+db = db_factory(init=init_script)
+
+test_script = """SELECT
+  dt.*
+FROM
+  Table_10 t10
+  JOIN (SELECT * FROM Table_10 t2 WHERE t2.ID = t10.ID) dt ON (1 = 1);"""
+
+act = isql_act('db', test_script, substitutions=[('-At line.*','')])
+
+expected_stderr = """
+Statement failed, SQLSTATE = 42S22
+Dynamic SQL Error
+-SQL error code = -206
+-Column unknown
+-T10.ID
+-At line 5, column 53
+"""
+
+@pytest.mark.version('>=3')
+def test_1(act: Action):
+    act.expected_stderr = expected_stderr
+    act.execute()
+    assert act.clean_stderr == act.clean_expected_stderr

--- a/tests/functional/arno/derived_tables/test_24.py
+++ b/tests/functional/arno/derived_tables/test_24.py
@@ -1,0 +1,56 @@
+#coding:utf-8
+
+"""
+ID:          derived-table-24
+TITLE:       Derived table with outer reference from LEFT JOIN.
+DESCRIPTION: Outer reference inside derived table to other relations in from clause is not allowed.
+FBTEST:      functional.arno.derived_tables.26
+"""
+
+import pytest
+from firebird.qa import *
+
+init_script = """CREATE TABLE Table_10 (
+  ID INTEGER NOT NULL,
+  DESCRIPTION VARCHAR(10)
+);
+
+COMMIT;
+
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (0, NULL);
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (1, 'one');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (2, 'two');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (3, 'three');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (4, 'four');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (5, 'five');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (6, 'six');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (7, 'seven');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (8, 'eight');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (9, 'nine');
+
+COMMIT;"""
+
+db = db_factory(init=init_script)
+
+test_script = """SELECT
+  dt.*
+FROM
+  Table_10 t10
+  LEFT JOIN (SELECT * FROM Table_10 t2 WHERE t2.ID = t10.ID) dt ON (1 = 1);"""
+
+act = isql_act('db', test_script, substitutions=[('-At line.*','')])
+
+expected_stderr = """
+Statement failed, SQLSTATE = 42S22
+Dynamic SQL Error
+-SQL error code = -206
+-Column unknown
+-T10.ID
+-At line 5, column 58
+"""
+
+@pytest.mark.version('>=3')
+def test_1(act: Action):
+    act.expected_stderr = expected_stderr
+    act.execute()
+    assert act.clean_stderr == act.clean_expected_stderr

--- a/tests/functional/arno/derived_tables/test_25.py
+++ b/tests/functional/arno/derived_tables/test_25.py
@@ -1,0 +1,56 @@
+#coding:utf-8
+
+"""
+ID:          derived-table-25
+TITLE:       Derived table with outer reference from FULL JOIN.
+DESCRIPTION: Outer reference inside derived table to other relations in from clause is not allowed.
+FBTEST:      functional.arno.derived_tables.27
+"""
+
+import pytest
+from firebird.qa import *
+
+init_script = """CREATE TABLE Table_10 (
+  ID INTEGER NOT NULL,
+  DESCRIPTION VARCHAR(10)
+);
+
+COMMIT;
+
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (0, NULL);
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (1, 'one');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (2, 'two');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (3, 'three');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (4, 'four');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (5, 'five');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (6, 'six');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (7, 'seven');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (8, 'eight');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (9, 'nine');
+
+COMMIT;"""
+
+db = db_factory(init=init_script)
+
+test_script = """SELECT
+  dt.*
+FROM
+  Table_10 t10
+  FULL JOIN (SELECT * FROM Table_10 t2 WHERE t2.ID = t10.ID) dt ON (1 = 1);"""
+
+act = isql_act('db', test_script, substitutions=[('-At line.*','')])
+
+expected_stderr = """
+Statement failed, SQLSTATE = 42S22
+Dynamic SQL Error
+-SQL error code = -206
+-Column unknown
+-T10.ID
+-At line 5, column 58
+"""
+
+@pytest.mark.version('>=3')
+def test_1(act: Action):
+    act.expected_stderr = expected_stderr
+    act.execute()
+    assert act.clean_stderr == act.clean_expected_stderr

--- a/tests/functional/arno/derived_tables/test_26.py
+++ b/tests/functional/arno/derived_tables/test_26.py
@@ -1,0 +1,54 @@
+#coding:utf-8
+
+"""
+ID:          derived-table-26
+TITLE:       Derived table with non-unique column names.
+DESCRIPTION: Expect an error if a derived table column names is not unique.
+FBTEST:      functional.arno.derived_tables.29
+"""
+
+import pytest
+from firebird.qa import *
+
+init_script = """CREATE TABLE Table_10 (
+  ID INTEGER NOT NULL,
+  DESCRIPTION VARCHAR(10)
+);
+
+COMMIT;
+
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (0, NULL);
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (1, 'one');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (2, 'two');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (3, 'three');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (4, 'four');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (5, 'five');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (6, 'six');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (7, 'seven');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (8, 'eight');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (9, 'nine');
+
+COMMIT;"""
+
+db = db_factory(init=init_script)
+
+test_script = """SELECT
+  dt.*
+FROM
+  (SELECT ID, ID FROM Table_10 t10) dt;"""
+
+act = isql_act('db', test_script)
+
+expected_stderr = """
+Statement failed, SQLSTATE = 42000
+Dynamic SQL Error
+-SQL error code = -104
+-Invalid command
+-column ID was specified multiple times for derived table DT
+"""
+
+@pytest.mark.version('>=3')
+def test_1(act: Action):
+    act.expected_stderr = expected_stderr
+    act.execute()
+    assert act.clean_stderr == act.clean_expected_stderr

--- a/tests/functional/arno/derived_tables/test_27.py
+++ b/tests/functional/arno/derived_tables/test_27.py
@@ -1,0 +1,54 @@
+#coding:utf-8
+
+"""
+ID:          derived-table-27
+TITLE:       Derived table with non-unique column aliases.
+DESCRIPTION: Expect an error if a derived table column aliases is not unique.
+FBTEST:      functional.arno.derived_tables.30
+"""
+
+import pytest
+from firebird.qa import *
+
+init_script = """CREATE TABLE Table_10 (
+  ID INTEGER NOT NULL,
+  DESCRIPTION VARCHAR(10)
+);
+
+COMMIT;
+
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (0, NULL);
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (1, 'one');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (2, 'two');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (3, 'three');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (4, 'four');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (5, 'five');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (6, 'six');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (7, 'seven');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (8, 'eight');
+INSERT INTO Table_10 (ID, DESCRIPTION) VALUES (9, 'nine');
+
+COMMIT;"""
+
+db = db_factory(init=init_script)
+
+test_script = """SELECT
+  dt.*
+FROM
+  (SELECT * FROM Table_10 t10) dt (ID, ID);"""
+
+act = isql_act('db', test_script)
+
+expected_stderr = """
+Statement failed, SQLSTATE = 42000
+Dynamic SQL Error
+-SQL error code = -104
+-Invalid command
+-column ID was specified multiple times for derived table DT
+"""
+
+@pytest.mark.version('>=3')
+def test_1(act: Action):
+    act.expected_stderr = expected_stderr
+    act.execute()
+    assert act.clean_stderr == act.clean_expected_stderr


### PR DESCRIPTION
These tests were previously added in a local fork of fbt-repository from QMTest suite but not added in the main fbt-repository.
If the changes are approved, please add them through merge to sync the fork.