### PR TITLE
Config replacement support

### DIFF
--- a/src/firebird/qa/__init__.py
+++ b/src/firebird/qa/__init__.py
@@ -40,4 +40,4 @@
 
 from .plugin import db_factory, Database, user_factory, User, isql_act, python_act, Action, \
      temp_file, temp_files, role_factory, Role, envar_factory, Envar, Mapping, mapping_factory, \
-     ServerKeeper, ExecutionError, QA_GLOBALS, existing_db_factory
+     ServerKeeper, ExecutionError, QA_GLOBALS, existing_db_factory, ConfigManager

--- a/tests/bugs/gh_8485_test.py
+++ b/tests/bugs/gh_8485_test.py
@@ -35,18 +35,14 @@ WRONG_DBCONF = """
 """
 
 @pytest.mark.version('>=3.0.13')
-def test_1(act: Action, tmp_file: Path, capsys):
+def test_1(act: Action, tmp_file: Path, store_config: ConfigManager, capsys):
 
+    store_config.replace('databases.conf', WRONG_DBCONF)
     try:
-        shutil.copy2(act.home_dir/'databases.conf', tmp_file)
-        with open(act.home_dir/'databases.conf', 'w') as f:
-            f.write(WRONG_DBCONF)
         act.isql(switches = ['-q'], input = f'connect {act.db.dsn};', combine_output = True)
     except Error as e:
         # Despite crash, no messages were issued here before fix.
         print(e)
-    finally:
-        shutil.copy2(tmp_file, act.home_dir/'databases.conf')
     
     for line in act.stdout.splitlines():
         if (pos := line.lower().find('databases.conf')) > 0:


### PR DESCRIPTION
Added a new class ConfigManager.
1. replace() replaces specified config.
- The first argument should be the relative (to the home directory) path of the configuration file.
- The second argument can be either the new content or the path to the file with the new content.
- The first method call creates a backup of the configuration file.
2. add() adds new content to the specified config.
- The method is similar to replace() except that the new content is added to the end of the specified config.
3. restore() restores all changed configs.
- The argument "final" is responsible for deleting the backup file after the restore. The default value is False. The True value is only used when calling the method after the test has finished, you should not use final=True within the test.

ConfigManager objects should not be created directly, only using the store_config fixture. When the test has finished, the fixture will restore any modified configuration files.

Updated the tests/bugs/gh_8485_test.py test to demonstrate the use of a new store_config fixture.