### PR TITLE
Add sortedcontainers as the plugin dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "firebird-driver~=2.0",
     "pytest>=7.4",
     "psutil~=5.9",
+    "sortedcontainers>=2.4.0"
     ]
 
 [project.urls]


### PR DESCRIPTION
Need to add after remaking the tests/bugs/core_3672_test.py test.